### PR TITLE
[0813#機能] ボタンの範囲制御

### DIFF
--- a/app/rankings/components/RankingItemCard.tsx
+++ b/app/rankings/components/RankingItemCard.tsx
@@ -5,7 +5,6 @@ import {
   Card,
   CardHeader,
   Collapse,
-  IconButton,
   Link as MUILink,
   List,
   ListItem,
@@ -14,8 +13,6 @@ import {
   Typography,
 } from "@material-ui/core"
 import LooksOneIcon from "@material-ui/icons/LooksOne"
-import clsx from "clsx"
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
 import {
   Filter4,
   Filter5,
@@ -39,16 +36,6 @@ const useStyles = makeStyles((theme) => ({
   },
   card: {
     marginTop: theme.spacing(1),
-  },
-  expand: {
-    transform: "rotate(0deg)",
-    marginLeft: "auto",
-    transition: theme.transitions.create("transform", {
-      duration: theme.transitions.duration.shortest,
-    }),
-  },
-  expandOpen: {
-    transform: "rotate(180deg)",
   },
 }))
 
@@ -137,15 +124,7 @@ export const RankingItemCard: React.FC<ItemCardProps> = (props) => {
     <Card className={classes.card}>
       <CardHeader
         avatar={<RankAvatar rank={props.rank} />}
-        action={
-          <IconButton
-            className={clsx(classes.expand, { [classes.expandOpen]: expand })}
-            aria-label="expand more"
-            onClick={() => setExpand(!expand)}
-          >
-            <ExpandMoreIcon />
-          </IconButton>
-        }
+        onClick={() => setExpand(!expand)}
         title={<Typography variant={"h6"}>{props.title}</Typography>}
         subheader={props.subheader}
       />

--- a/app/rankings/components/RankingItemCard.tsx
+++ b/app/rankings/components/RankingItemCard.tsx
@@ -1,10 +1,13 @@
 import React, { useState } from "react"
 import { Link, Routes } from "blitz"
+import clsx from "clsx"
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
 import {
   Avatar,
   Card,
   CardHeader,
   Collapse,
+  IconButton,
   Link as MUILink,
   List,
   ListItem,
@@ -36,6 +39,16 @@ const useStyles = makeStyles((theme) => ({
   },
   card: {
     marginTop: theme.spacing(1),
+  },
+  expand: {
+    transform: "rotate(0deg)",
+    marginLeft: "auto",
+    transition: theme.transitions.create("transform", {
+      duration: theme.transitions.duration.shortest,
+    }),
+  },
+  expandOpen: {
+    transform: "rotate(180deg)",
   },
 }))
 
@@ -125,6 +138,14 @@ export const RankingItemCard: React.FC<ItemCardProps> = (props) => {
       <CardHeader
         avatar={<RankAvatar rank={props.rank} />}
         onClick={() => setExpand(!expand)}
+        action={
+          <IconButton
+            className={clsx(classes.expand, { [classes.expandOpen]: expand })}
+            aria-label="expand more"
+          >
+            <ExpandMoreIcon />
+          </IconButton>
+        }
         title={<Typography variant={"h6"}>{props.title}</Typography>}
         subheader={props.subheader}
       />

--- a/app/rankings/pages/rankings/[rankingId]/items/[itemId]/c/[cRankingId]/[cItemId].tsx
+++ b/app/rankings/pages/rankings/[rankingId]/items/[itemId]/c/[cRankingId]/[cItemId].tsx
@@ -5,6 +5,7 @@ import getRanking from "../../../../../../../queries/getRanking"
 import React, { Suspense } from "react"
 import { Button, makeStyles, Typography } from "@material-ui/core"
 import TwitterIcon from "@material-ui/icons/Twitter"
+import Loading from "app/components/Loading"
 import { RankingItem } from "../../../../../../../../ranking-items/validations"
 import { AppLink } from "../../../../../../../../core/components/AppLink"
 
@@ -186,7 +187,7 @@ const Compare: React.FC = () => {
 const ComparePage: BlitzPage = () => {
   return (
     <>
-      <Suspense fallback={<div>Loading...</div>}>
+      <Suspense fallback={<Loading />}>
         <Compare />
       </Suspense>
     </>


### PR DESCRIPTION
### 実装内容

- ボタンonClick制御を右上のみからカードヘッダー部分に制御
- tweet画面の部分のLoading実装が不足していたため追加