### PR TITLE
[0814#デザイン修正] Top, ランキング作成画面のレイアウトを修正

### DIFF
--- a/app/core/components/LinkListItem.tsx
+++ b/app/core/components/LinkListItem.tsx
@@ -1,16 +1,24 @@
 import { Link, LinkProps } from "blitz"
-import { Link as MUILink, ListItem, ListItemText } from "@material-ui/core"
+import { Link as MUILink, ListItem, ListItemText, makeStyles } from "@material-ui/core"
 import React from "react"
 
 type Props = {
   text: string
 } & LinkProps
 
+const useStyles = makeStyles((_theme) => ({
+  linkListItem: {
+    borderBottom: "1px solid #dcdcdc",
+    padding: _theme.spacing(1),
+  },
+}))
+
 export const LinkListItem: React.FC<Props> = (props) => {
+  const classes = useStyles()
   return (
     <Link href={props.href}>
       <MUILink href="#">
-        <ListItem>
+        <ListItem className={classes.linkListItem}>
           <ListItemText primary={props.text} color={"primary"} />
         </ListItem>
       </MUILink>

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -8,17 +8,72 @@ import {
   makeStyles,
   Typography,
 } from "@material-ui/core"
+import { NewReleases, Star, ArrowForwardIos, Create } from "@material-ui/icons"
 import React, { Suspense } from "react"
 import Meta from "../components/Meta"
 import Loading from "app/components/Loading"
 import { Header } from "../components/Header"
 import getRankings from "../rankings/queries/getRankings"
 import { LinkListItem } from "../core/components/LinkListItem"
+import { AppLink } from "../core/components/AppLink"
 
 const useStyles = makeStyles((_theme) => ({
+  mainContentWrapper: {
+    textAlign: "center",
+    border: "1px solid #808080",
+    borderRadius: "4px",
+  },
   moreButtonWrapper: {
     display: "flex",
     justifyContent: "flex-end",
+  },
+  contentWrapper: {
+    display: "flex",
+    justifyContent: "center",
+  },
+  siteTitle: {
+    fontSize: "16px",
+    fontWeight: "bold",
+    padding: _theme.spacing(1),
+    borderBottom: "1px solid #808080",
+  },
+  description: {
+    padding: _theme.spacing(1),
+    textAlign: "left",
+  },
+  listTitle: {
+    backgroundColor: "#d3d3d3",
+    fontSize: "18px",
+    fontWeight: "bold",
+    padding: _theme.spacing(1),
+  },
+  listTitleIcon: {
+    position: "absolute",
+  },
+  listTitleText: {
+    marginLeft: _theme.spacing(4),
+  },
+  listMoreButton: {
+    fontSize: "8px",
+    color: "#808080",
+    marginBottom: _theme.spacing(2),
+    borderRadius: "4px",
+    border: "1px solid #808080",
+  },
+  listMoreIcon: {
+    fontSize: "10px",
+    marginRight: "2px",
+    position: "relative",
+    top: "-0.5px",
+  },
+  buttonPrimary: {
+    backgroundColor: "#3f51b5",
+    color: "white",
+    marginTop: _theme.spacing(2),
+    marginBottom: _theme.spacing(2),
+  },
+  buttonText: {
+    marginLeft: "2px",
   },
 }))
 
@@ -46,28 +101,52 @@ const Top: BlitzPage = () => {
       <Header />
       <Container>
         <Meta />
-        <Typography variant={"h5"}>新着ランキング</Typography>
+        <Container className={classes.mainContentWrapper}>
+          <Typography className={classes.siteTitle}>たぶんアレくらいとは</Typography>
+          <Typography className={classes.description}>
+            ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト
+          </Typography>
+        </Container>
+        <Container className={classes.contentWrapper}>
+          <AppLink href={Routes.NewRankingPage()}>
+            <Button className={classes.buttonPrimary}>
+              <Create />
+              <span className={classes.buttonText}>ランキングを作る</span>
+            </Button>
+          </AppLink>
+        </Container>
+
+        <Typography className={classes.listTitle}>
+          <NewReleases className={classes.listTitleIcon} />
+          <span className={classes.listTitleText}>新着ランキング</span>
+        </Typography>
         <Suspense fallback={<Loading />}>
           <LatestRankings />
         </Suspense>
         <div className={classes.moreButtonWrapper}>
           <Link href={Routes.RankingsPage()}>
-            <Button color={"inherit"}>もっと見る</Button>
+            <Button color={"inherit"} className={classes.listMoreButton}>
+              <ArrowForwardIos className={classes.listMoreIcon} />
+              もっと見る
+            </Button>
           </Link>
         </div>
-        <Typography variant={"h5"}>人気ランキング</Typography>
+        <Typography className={classes.listTitle}>
+          <Star className={classes.listTitleIcon} />
+          <span className={classes.listTitleText}>人気ランキング</span>
+        </Typography>
         <List dense={true}>
           <ListItem>
             <ListItemText primary="Coming soon..." />
           </ListItem>
         </List>
-        <div className={classes.moreButtonWrapper}>
+        {/* <div className={classes.moreButtonWrapper}>
           <Link href={"/"}>
-            <Button disabled={true} color={"inherit"}>
-              もっと見る
+            <Button color={"inherit"} className={classes.listMoreButton}>
+              <ArrowForwardIos className={classes.listMoreIcon} />もっと見る
             </Button>
           </Link>
-        </div>
+        </div> */}
       </Container>
     </>
   )

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -140,13 +140,6 @@ const Top: BlitzPage = () => {
             <ListItemText primary="Coming soon..." />
           </ListItem>
         </List>
-        {/* <div className={classes.moreButtonWrapper}>
-          <Link href={"/"}>
-            <Button color={"inherit"} className={classes.listMoreButton}>
-              <ArrowForwardIos className={classes.listMoreIcon} />もっと見る
-            </Button>
-          </Link>
-        </div> */}
       </Container>
     </>
   )

--- a/app/rankings/pages/rankings/index.tsx
+++ b/app/rankings/pages/rankings/index.tsx
@@ -4,11 +4,37 @@ import { usePaginatedQuery, useRouter, BlitzPage, Routes } from "blitz"
 import Layout from "app/core/layouts/Layout"
 import Loading from "app/components/Loading"
 import getRankings from "app/rankings/queries/getRankings"
-import { Button, Typography } from "@material-ui/core"
+import { Button, Typography, makeStyles } from "@material-ui/core"
+import { NewReleases, Create } from "@material-ui/icons"
 import { RankingList } from "../../components/RankingList"
 import { AppLink } from "../../../core/components/AppLink"
 
 const ITEMS_PER_PAGE = 10
+
+const useStyles = makeStyles((_theme) => ({
+  listTitle: {
+    backgroundColor: "#d3d3d3",
+    fontSize: "18px",
+    fontWeight: "bold",
+    padding: _theme.spacing(1),
+  },
+  listTitleIcon: {
+    position: "absolute",
+  },
+  listTitleText: {
+    marginLeft: _theme.spacing(4),
+  },
+  buttonPrimary: {
+    margin: "0px auto",
+    marginTop: _theme.spacing(1),
+    width: "100%",
+    backgroundColor: "#3f51b5",
+    color: "white",
+  },
+  buttonText: {
+    marginLeft: "2px",
+  },
+}))
 
 export const PaginatedRankingList = () => {
   const router = useRouter()
@@ -35,17 +61,26 @@ export const PaginatedRankingList = () => {
 }
 
 const RankingsPage: BlitzPage = () => {
+  const classes = useStyles()
   return (
     <>
       <Meta title="新着ランキング" />
       <div>
-        <Typography variant={"h5"}>新着ランキング</Typography>
+        <Typography className={classes.listTitle}>
+          <NewReleases className={classes.listTitleIcon} />
+          <span className={classes.listTitleText}>新着ランキング</span>
+        </Typography>
         <Suspense fallback={<Loading />}>
           <PaginatedRankingList />
         </Suspense>
       </div>
       <p>
-        <AppLink href={Routes.NewRankingPage()}>ランキングを作る</AppLink>
+        <AppLink href={Routes.NewRankingPage()}>
+          <Button className={classes.buttonPrimary}>
+            <Create />
+            <span className={classes.buttonText}>ランキングを作る</span>
+          </Button>
+        </AppLink>
       </p>
     </>
   )


### PR DESCRIPTION
### 実装内容

- Topのレイアウトを調整、サイトの説明項目や作成ボタンの追加を行った
- 新着ランキングレイアウトを調整

### Top画面
![スクリーンショット 2021-08-13 123313](https://user-images.githubusercontent.com/14093191/129301437-7087b245-1546-400e-81d6-51ac0568ab42.jpg)

### 新着ランキング画面
![image](https://user-images.githubusercontent.com/14093191/129301399-4e1d28a9-0dee-4635-87e5-cbbb85cf148d.png)
