### PR TITLE
[機能#0829] footerの追加

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -47,21 +47,18 @@ export const Footer = () => {
           <p className={classes.label}>新規作成</p>
         </div>
       </Link>
-      {session.userId ? (
-        <Link href={Routes.UserPage({ userId: session.userId as string })}>
-          <div className={classes.iconItem}>
-            <PermIdentity className={classes.icon} />
-            <p className={classes.label}>マイページ</p>
-          </div>
-        </Link>
-      ) : (
-        <Link href={Routes.LoginPage()}>
-          <div className={classes.iconItem}>
-            <PermIdentity className={classes.icon} />
-            <p className={classes.label}>マイページ</p>
-          </div>
-        </Link>
-      )}
+      <Link
+        href={
+          session.userId
+            ? Routes.UserPage({ userId: session.userId as string })
+            : Routes.LoginPage()
+        }
+      >
+        <div className={classes.iconItem}>
+          <PermIdentity className={classes.icon} />
+          <p className={classes.label}>マイページ</p>
+        </div>
+      </Link>
     </div>
   )
 }

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,5 +1,5 @@
 import { makeStyles } from "@material-ui/core"
-import { Home, Create, PhoneInTalk } from "@material-ui/icons"
+import { Home, Create, PermIdentity } from "@material-ui/icons"
 import React, { useState, Suspense } from "react"
 import { Link, Routes, useRouter, useSession } from "blitz"
 
@@ -17,6 +17,7 @@ const useStyles = makeStyles((theme) => ({
   },
   iconItem: {
     display: "block",
+    cursor: "pointer",
   },
   icon: {
     fontSize: "1.5rem",
@@ -34,18 +35,33 @@ export const Footer = () => {
   const router = useRouter()
   return (
     <div className={classes.footer}>
-      <div className={classes.iconItem}>
-        <Home className={classes.icon} />
-        <p className={classes.label}>ホーム</p>
-      </div>
-      <div className={classes.iconItem}>
-        <Create className={classes.icon} />
-        <p className={classes.label}>新規作成</p>
-      </div>
-      <div className={classes.iconItem}>
-        <PhoneInTalk className={classes.icon} />
-        <p className={classes.label}>お問い合わせ</p>
-      </div>
+      <Link href={"/"}>
+        <div className={classes.iconItem}>
+          <Home className={classes.icon} />
+          <p className={classes.label}>TOP</p>
+        </div>
+      </Link>
+      <Link href={Routes.NewRankingPage()}>
+        <div className={classes.iconItem}>
+          <Create className={classes.icon} />
+          <p className={classes.label}>新規作成</p>
+        </div>
+      </Link>
+      {session.userId ? (
+        <Link href={Routes.UserPage({ userId: session.userId as string })}>
+          <div className={classes.iconItem}>
+            <PermIdentity className={classes.icon} />
+            <p className={classes.label}>マイページ</p>
+          </div>
+        </Link>
+      ) : (
+        <Link href={Routes.LoginPage()}>
+          <div className={classes.iconItem}>
+            <PermIdentity className={classes.icon} />
+            <p className={classes.label}>マイページ</p>
+          </div>
+        </Link>
+      )}
     </div>
   )
 }

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,0 +1,51 @@
+import { makeStyles } from "@material-ui/core"
+import { Home, Create, PhoneInTalk } from "@material-ui/icons"
+import React, { useState, Suspense } from "react"
+import { Link, Routes, useRouter, useSession } from "blitz"
+
+const useStyles = makeStyles((theme) => ({
+  footer: {
+    display: "flex",
+    justifyContent: "space-around",
+    width: "100%",
+    backgroundColor: "gray",
+    color: "#fff",
+    textAlign: "center",
+    padding: "5px 10%",
+    position: "fixed",
+    bottom: "0",
+  },
+  iconItem: {
+    display: "block",
+  },
+  icon: {
+    fontSize: "1.5rem",
+  },
+  label: {
+    margin: "0px",
+    fontSize: "0.6rem",
+  },
+}))
+
+export const Footer = () => {
+  const classes = useStyles()
+  const session = useSession()
+
+  const router = useRouter()
+  return (
+    <div className={classes.footer}>
+      <div className={classes.iconItem}>
+        <Home className={classes.icon} />
+        <p className={classes.label}>ホーム</p>
+      </div>
+      <div className={classes.iconItem}>
+        <Create className={classes.icon} />
+        <p className={classes.label}>新規作成</p>
+      </div>
+      <div className={classes.iconItem}>
+        <PhoneInTalk className={classes.icon} />
+        <p className={classes.label}>お問い合わせ</p>
+      </div>
+    </div>
+  )
+}

--- a/app/components/Loading.tsx
+++ b/app/components/Loading.tsx
@@ -8,6 +8,7 @@ const Loading = () => {
       marginRight: "auto",
       width: "max-content",
       marginTop: "10vh",
+      marginBottom: "10vh",
       display: "block",
     },
   }))

--- a/app/core/layouts/Layout.tsx
+++ b/app/core/layouts/Layout.tsx
@@ -8,7 +8,7 @@ type LayoutProps = {
 }
 
 const useStyles = makeStyles((theme) => ({
-  contentWrapp: {
+  contentWrap: {
     paddingBottom: "60px",
   },
 }))
@@ -19,7 +19,7 @@ const Layout = ({ children }: LayoutProps) => {
     <>
       <Header />
       {/* FIXME */}
-      <Container className={classes.contentWrapp}>{children as any}</Container>
+      <Container className={classes.contentWrap}>{children as any}</Container>
       <Footer />
     </>
   )

--- a/app/core/layouts/Layout.tsx
+++ b/app/core/layouts/Layout.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from "react"
 import { Header } from "../../components/Header"
+import { Footer } from "../../components/Footer"
 import { Container } from "@material-ui/core"
 
 type LayoutProps = {
@@ -12,6 +13,7 @@ const Layout = ({ children }: LayoutProps) => {
       <Header />
       {/* FIXME */}
       <Container>{children as any}</Container>
+      <Footer />
     </>
   )
 }

--- a/app/core/layouts/Layout.tsx
+++ b/app/core/layouts/Layout.tsx
@@ -1,18 +1,25 @@
 import React, { ReactNode } from "react"
 import { Header } from "../../components/Header"
 import { Footer } from "../../components/Footer"
-import { Container } from "@material-ui/core"
+import { Container, makeStyles } from "@material-ui/core"
 
 type LayoutProps = {
   children: ReactNode
 }
 
+const useStyles = makeStyles((theme) => ({
+  contentWrapp: {
+    paddingBottom: "60px",
+  },
+}))
+
 const Layout = ({ children }: LayoutProps) => {
+  const classes = useStyles()
   return (
     <>
       <Header />
       {/* FIXME */}
-      <Container>{children as any}</Container>
+      <Container className={classes.contentWrapp}>{children as any}</Container>
       <Footer />
     </>
   )

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -13,10 +13,14 @@ import React, { Suspense } from "react"
 import Meta from "../components/Meta"
 import Loading from "app/components/Loading"
 import { Header } from "../components/Header"
+import { Footer } from "../components/Footer"
 import getRankings from "../rankings/queries/getRankings"
 import { LinkListItem } from "../core/components/LinkListItem"
 
 const useStyles = makeStyles((_theme) => ({
+  contentWrapp: {
+    paddingBottom: "60px",
+  },
   mainContentWrapper: {
     textAlign: "center",
     border: "1px solid #808080",
@@ -96,7 +100,7 @@ const Top: BlitzPage = () => {
   return (
     <>
       <Header />
-      <Container>
+      <Container className={classes.contentWrapp}>
         <Meta />
         <Container className={classes.mainContentWrapper}>
           <Typography className={classes.siteTitle}>たぶんアレくらいとは</Typography>
@@ -138,6 +142,7 @@ const Top: BlitzPage = () => {
           </ListItem>
         </List>
       </Container>
+      <Footer />
     </>
   )
 }

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -18,7 +18,7 @@ import getRankings from "../rankings/queries/getRankings"
 import { LinkListItem } from "../core/components/LinkListItem"
 
 const useStyles = makeStyles((_theme) => ({
-  contentWrapp: {
+  contentWrap: {
     paddingBottom: "60px",
   },
   mainContentWrapper: {
@@ -100,7 +100,7 @@ const Top: BlitzPage = () => {
   return (
     <>
       <Header />
-      <Container className={classes.contentWrapp}>
+      <Container className={classes.contentWrap}>
         <Meta />
         <Container className={classes.mainContentWrapper}>
           <Typography className={classes.siteTitle}>たぶんアレくらいとは</Typography>


### PR DESCRIPTION
### 実装内容

footerのレイアウト、項目、導線の追加
- ３つの項目「Top, 新規作成, マイページ」のアイコン、ページ遷移制御
- Topとその他ページにフッターが追加されるようにfooterを追加

![image](https://user-images.githubusercontent.com/14093191/132085829-3346f1cd-e6b2-4509-9292-1086598bd080.png)
